### PR TITLE
Add email-validator

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,6 +15,7 @@
                 "better-sqlite3-session-store": "^0.1.0",
                 "body-parser": "^1.20.2",
                 "dotenv": "^16.3.1",
+                "email-validator": "^2.0.4",
                 "express": "^4.18.2",
                 "express-session": "^1.17.3",
                 "jsonwebtoken": "^9.0.2",
@@ -1586,6 +1587,14 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+        },
+        "node_modules/email-validator": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
+            "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+            "engines": {
+                "node": ">4.0"
+            }
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",

--- a/api/package.json
+++ b/api/package.json
@@ -15,6 +15,7 @@
         "better-sqlite3-session-store": "^0.1.0",
         "body-parser": "^1.20.2",
         "dotenv": "^16.3.1",
+        "email-validator": "^2.0.4",
         "express": "^4.18.2",
         "express-session": "^1.17.3",
         "jsonwebtoken": "^9.0.2",

--- a/api/src/routes/registration/Registration.ts
+++ b/api/src/routes/registration/Registration.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { emailUsed, registerUser, usernameUsed } from '../../database/Users';
 import { pbkdf2Sync, randomBytes } from 'crypto';
+import * as EmailValidator from 'email-validator';
 
 const registration = Router();
 
@@ -29,7 +30,7 @@ registration.post('/register', async (req, res, next) => {
         res.status(400).send('Invalid email - unable to parse');
         return;
     }
-    if (!email.match(/^[\w\-\.]+@([\w-]+\.)+[\w-]{2,4}$/)) {
+    if (!EmailValidator.validate(email)) {
         res.status(400).send('Invalid email - invalid format');
         return;
     }


### PR DESCRIPTION
Possible solution to TLD for email addresses between `{2,4}`

I was able to get it to run, but could not validate as it required postgresql for validation. :|
